### PR TITLE
Adding RSpec and refactoring

### DIFF
--- a/lib/video_player.rb
+++ b/lib/video_player.rb
@@ -1,37 +1,62 @@
 require "video_player/version"
 
 module VideoPlayer
-  def self.player url, width = "420", height = "315", autoplay = true
-    if url.include? "youtu"
-      regex = /(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
-      url.gsub(regex) do
-        youtube_id = $4
-        if autoplay
-          src = "//www.youtube.com/embed/#{youtube_id}?autoplay=1&rel=0"
-        else
-          src = "//www.youtube.com/embed/#{youtube_id}?autoplay=0&rel=0"
-        end
-        return %{<iframe width="#{width}" height="#{height}" src="#{src}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>}
+  def self.player(*args)
+    VideoPlayer::Parser.new(*args).embed_code
+  end
+
+  class Parser
+    DefaultWidth = '420'
+    DefaultHeight = '315'
+    DefaultAutoPlay = true
+
+    YouTubeRegex  = /\A(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/i
+    VimeoRegex    = /\Ahttps?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/i
+    IzleseneRegex = /\Ahttp:\/\/(?:.*?)\izlesene\.com\/video\/([\w\-\.]+[^#?\s]+)\/(.*)?$/i
+
+    attr_accessor :url, :width, :height
+
+    def initialize(url, width = DefaultWidth, height = DefaultHeight, autoplay = DefaultAutoPlay)
+      @url = url
+      @width = width
+      @height = height
+      @autoplay = autoplay
+    end
+
+    def embed_code
+      case
+      when matchdata = url.match(YouTubeRegex)
+        youtube_embed(matchdata[4])
+      when matchdata = url.match(VimeoRegex)
+        vimeo_embed(matchdata[2])
+      when matchdata = url.match(IzleseneRegex)
+        izlesene_embed(matchdata[2])
+      else
+        false
       end
-    elsif url.include? "vimeo"
-      url.gsub(/https?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/) do
-        vimeo_id = $2
-        frameborder = 0
-        return %{<iframe src="//player.vimeo.com/video/#{vimeo_id}" width="#{width}" height="#{height}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>}
-      end
-    elsif url.include? "izlesene"
-      regex = /^http:\/\/(?:.*?)\izlesene\.com\/video\/([\w\-\.]+[^#?\s]+)\/(.*)?$/i
-      url.gsub(regex) do
-        izlesene_video_id = $2
-        if autoplay
-          src = "//www.izlesene.com/embedplayer/#{izlesene_video_id}/?autoplay=1&showrel=0&showinfo=0"
-        else
-          src = "//www.izlesene.com/embedplayer/#{izlesene_video_id}/?autoplay=0&showrel=0&showinfo=0"
-        end
-        return %{<iframe width="#{width}" height="#{height}" src="#{src}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>}
-      end
-    else
-      return false
+    end
+
+    def autoplay
+      !!@autoplay ? '1' : '0'
+    end
+
+    def iframe_code(src)
+      %{<iframe src="#{src}" width="#{width}" height="#{height}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>}
+    end
+
+    def youtube_embed(youtube_id)
+      src = "//www.youtube.com/embed/#{youtube_id}?autoplay=#{autoplay}&rel=0"
+      iframe_code(src)
+    end
+
+    def vimeo_embed(vimeo_id)
+      src = "//player.vimeo.com/video/#{vimeo_id}"
+      iframe_code(src)
+    end
+
+    def izlesene_embed(izlesene_video_id)
+      src = "//www.izlesene.com/embedplayer/#{izlesene_video_id}/?autoplay=#{autoplay}&showrel=0&showinfo=0"
+      iframe_code(src)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'rspec'
+
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'video_player'

--- a/spec/video_player/video_player_spec.rb
+++ b/spec/video_player/video_player_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe VideoPlayer do
+
+  describe "existing API" do
+    let(:parser) { VideoPlayer::Parser.new('https://www.youtube.com/watch?v=12345678') }
+
+    it "passes the player method to an instance of VideoPlayer::Parser" do
+      expect(VideoPlayer::Parser).to receive(:new).once.and_return(VideoPlayer::Parser.new('url'))
+      VideoPlayer::player('https://www.youtube.com/watch?v=12345678')
+    end
+  end
+
+  describe "selecting video embed method" do
+
+    let(:width) { %|width="#{VideoPlayer::Parser::DefaultWidth}"| }
+    let(:height) { %|height="#{VideoPlayer::Parser::DefaultHeight}"| }
+    let(:attributes) { %|frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen| }
+
+    context "youtube links" do
+
+      let(:youtube_urls) { [
+        'http://youtube.com/watch?v=abcde12345',
+        'http://youtu.be/abcde12345',
+        'http://youtube.com/watch?feature=player_embedded&v=abcde12345',
+        'https://youtube.com/watch?v=abcde12345',
+        'https://youtu.be/abcde12345',
+        'https://youtube.com/watch?feature=player_embedded&v=abcde12345'
+      ]}
+
+      it "uses the youtube embed method" do
+        youtube_urls.each do |url|
+          parser = VideoPlayer::Parser.new(url)
+          expect(parser).to receive(:youtube_embed).once
+          parser.embed_code
+        end
+      end
+
+      it "returns a valid embed code" do
+        src = "//www.youtube.com/embed/abcde12345?autoplay=0&rel=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'https://youtube.com/watch?feature=player_embedded&v=abcde12345'
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+      end
+
+      it "returns a valid autoplay embed code" do
+        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=1&showrel=0&showinfo=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        expect(VideoPlayer.player(url)).to eq(code)
+      end
+    end
+
+    context "vimeo links" do
+      let(:vimeo_urls) { [
+        'http://vimeo.com/abcde12345',
+        'http://www.vimeo.com/abcde12345',
+        'https://vimeo.com/abcde12345',
+        'https://www.vimeo.com/abcde12345'
+      ]}
+
+      it "uses the youtube embed method" do
+        vimeo_urls.each do |url|
+          parser = VideoPlayer::Parser.new(url)
+          expect(parser).to receive(:vimeo_embed).once
+          parser.embed_code
+        end
+      end
+
+      it "returns a valid embed code" do
+        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=0&showrel=0&showinfo=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+      end
+
+      it "returns a valid autoplay embed code" do
+        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=1&showrel=0&showinfo=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        expect(VideoPlayer.player(url)).to eq(code)
+      end
+    end
+
+    context "izlesene links" do
+
+      let(:izlesene_urls) { [
+        'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678',
+        'http://www.izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+      ]}
+
+      it "uses the youtube embed method" do
+        izlesene_urls.each do |url|
+          parser = VideoPlayer::Parser.new(url)
+          expect(parser).to receive(:izlesene_embed).once
+          parser.embed_code
+        end
+      end
+
+      it "returns a valid embed code" do
+        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=0&showrel=0&showinfo=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+      end
+
+      it "returns a valid autoplay embed code" do
+        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=1&showrel=0&showinfo=0"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        expect(VideoPlayer.player(url)).to eq(code)
+      end
+
+    end
+  end
+
+
+end


### PR DESCRIPTION
- Existing API to just call an instance of VideoPlayer::Parser
- Move parser code into its own class for start of thread safety
- Use `match` instead of global regex variables
- Remove duplication of strings in the `video_player.rb` file
- Use one regex code for each type of video instead of two
- Add specs
