### PR TITLE
Add support for autoplay with vimeo videos

### DIFF
--- a/lib/video_player.rb
+++ b/lib/video_player.rb
@@ -53,7 +53,7 @@ module VideoPlayer
     end
 
     def vimeo_embed(video_id)
-      src = "//player.vimeo.com/video/#{video_id}"
+      src = "//player.vimeo.com/video/#{video_id}?autoplay=#{autoplay}"
       iframe_code(src)
     end
 

--- a/spec/video_player/video_player_spec.rb
+++ b/spec/video_player/video_player_spec.rb
@@ -45,10 +45,10 @@ describe VideoPlayer do
       end
 
       it "returns a valid autoplay embed code" do
-        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=1&showrel=0&showinfo=0"
+        src = "//www.youtube.com/embed/abcde12345?autoplay=1&rel=0"
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
-        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        url = 'http://youtube.com/watch?feature=player_embedded&v=abcde12345'
         expect(VideoPlayer.player(url)).to eq(code)
       end
     end
@@ -70,18 +70,18 @@ describe VideoPlayer do
       end
 
       it "returns a valid embed code" do
-        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=0&showrel=0&showinfo=0"
+        src = "//player.vimeo.com/video/12345678?autoplay=0"
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
-        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        url = 'http://www.vimeo.com/12345678?autoplay=0&loop=1&autopause=0'
         expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
       end
 
       it "returns a valid autoplay embed code" do
-        src = "//www.izlesene.com/embedplayer/12345678/?autoplay=1&showrel=0&showinfo=0"
+        src = "//player.vimeo.com/video/12345678?autoplay=1"
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
-        url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
+        url = 'http://www.vimeo.com/12345678?autoplay=1&loop=1&autopause=0'
         expect(VideoPlayer.player(url)).to eq(code)
       end
     end


### PR DESCRIPTION
Vimeo supports autoplay but VideoPlayer doesn't set that parameter. I've added support for that so it works like it does on the other platforms.

I noticed that the tests for vimeo (and youtube) weren't testing the right thing, so I've fixed those up too.