### PR TITLE
Added an extra parameter for muting videos

### DIFF
--- a/lib/video_player.rb
+++ b/lib/video_player.rb
@@ -9,6 +9,7 @@ module VideoPlayer
     DefaultWidth = '420'
     DefaultHeight = '315'
     DefaultAutoPlay = true
+    DefaultMute = false
 
     YouTubeRegex  = /\A(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/i
     VimeoRegex    = /\Ahttps?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/i
@@ -17,11 +18,12 @@ module VideoPlayer
 
     attr_accessor :url, :width, :height
 
-    def initialize(url, width = DefaultWidth, height = DefaultHeight, autoplay = DefaultAutoPlay)
+    def initialize(url, width = DefaultWidth, height = DefaultHeight, autoplay = DefaultAutoPlay, mute = DefaultMute)
       @url = url
       @width = width
       @height = height
       @autoplay = autoplay
+      @mute = mute
     end
 
     def embed_code
@@ -49,11 +51,13 @@ module VideoPlayer
 
     def youtube_embed(video_id)
       src = "//www.youtube.com/embed/#{video_id}?autoplay=#{autoplay}&rel=0"
+      src << "&mute=1" if @mute
       iframe_code(src)
     end
 
     def vimeo_embed(video_id)
       src = "//player.vimeo.com/video/#{video_id}?autoplay=#{autoplay}"
+      src << "&muted=1" if @mute
       iframe_code(src)
     end
 

--- a/spec/video_player/video_player_spec.rb
+++ b/spec/video_player/video_player_spec.rb
@@ -41,7 +41,7 @@ describe VideoPlayer do
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
         url = 'https://youtube.com/watch?feature=player_embedded&v=abcde12345'
-        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, false)).to eq(code)
       end
 
       it "returns a valid autoplay embed code" do
@@ -50,6 +50,14 @@ describe VideoPlayer do
 
         url = 'http://youtube.com/watch?feature=player_embedded&v=abcde12345'
         expect(VideoPlayer.player(url)).to eq(code)
+      end
+
+      it "returns a valid mute embed code" do
+        src = "//www.youtube.com/embed/abcde12345?autoplay=0&rel=0&mute=1"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://youtube.com/watch?feature=player_embedded&v=abcde12345'
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, true)).to eq(code)
       end
     end
 
@@ -74,7 +82,7 @@ describe VideoPlayer do
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
         url = 'http://www.vimeo.com/12345678?autoplay=0&loop=1&autopause=0'
-        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, false)).to eq(code)
       end
 
       it "returns a valid autoplay embed code" do
@@ -83,6 +91,14 @@ describe VideoPlayer do
 
         url = 'http://www.vimeo.com/12345678?autoplay=1&loop=1&autopause=0'
         expect(VideoPlayer.player(url)).to eq(code)
+      end
+
+      it "returns a valid mute embed code" do
+        src = "//player.vimeo.com/video/12345678?autoplay=0&muted=1"
+        code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
+
+        url = 'http://www.vimeo.com/12345678?autoplay=0&loop=1&autopause=0'
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, true)).to eq(code)
       end
     end
 
@@ -106,7 +122,7 @@ describe VideoPlayer do
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
         url = 'http://izlesene.com/video/abcde-abcde-abcde-abcde-abcde/12345678'
-        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, false)).to eq(code)
       end
 
       it "returns a valid autoplay embed code" do
@@ -138,7 +154,7 @@ describe VideoPlayer do
         code = %|<iframe src="#{src}" #{width} #{height} #{attributes}></iframe>|
 
         url = 'https://company.wistia.com/medias/12345678'
-        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false)).to eq(code)
+        expect(VideoPlayer.player(url, VideoPlayer::Parser::DefaultWidth, VideoPlayer::Parser::DefaultHeight, false, false)).to eq(code)
       end
 
       it "returns a valid autoplay embed code" do


### PR DESCRIPTION
As suggested in #9, I've added an extra parameter for muting videos. I couldn't test it for wistia or izlesene so I've haven't implemented it for those two (it works for YouTube and Vimeo).

I decided to add it as a 5th positional parameter rather than a named parameter, but it might be worth refactoring to use url parameters?