### PR TITLE
Fix "Unknown escape \i is ignored" warning message

### DIFF
--- a/lib/video_player.rb
+++ b/lib/video_player.rb
@@ -12,7 +12,7 @@ module VideoPlayer
 
     YouTubeRegex  = /\A(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/i
     VimeoRegex    = /\Ahttps?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/i
-    IzleseneRegex = /\Ahttp:\/\/(?:.*?)\izlesene\.com\/video\/([\w\-\.]+[^#?\s]+)\/(.*)?$/i
+    IzleseneRegex = /\Ahttp:\/\/(?:.*?)izlesene\.com\/video\/([\w\-\.]+[^#?\s]+)\/(.*)?$/i
     WistiaRegex   = /\Ahttps?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/i
 
     attr_accessor :url, :width, :height


### PR DESCRIPTION
If you run ruby with warnings enabled there is a warning coming from the regex used for izlesene:

    warning: Unknown escape \i is ignored

There is no such escape character as `\i`. I think this should just be `i` so I've removed the `\`.